### PR TITLE
refactor: enhance seo

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -23,6 +23,8 @@ const {mathjax = false, mermaid = false} = Astro.props
   <meta property="og:url" content={Astro.url}/>
   <meta property="og:title" content={site.title}/>
   <meta property="og:description" content={site.description}/>
+  <meta property="og:image" content={new URL(site.avatar, Astro.site?.href).href}/>
+  <meta property="og:image:alt" content={site.description}/>
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image"/>

--- a/src/components/Donate.astro
+++ b/src/components/Donate.astro
@@ -9,20 +9,20 @@ import {donate} from "../consts";
     </div>
     <div class="flex items-center justify-center">
       <div id="alipay" class="border rounded-tl-lg rounded-bl-lg p-2">
-        <img src="/alipay.svg" class="h-4" alt=""/>
+        <img src="/alipay.svg" class="h-4" alt="alipay"/>
       </div>
       <div id="wechatpay" class="border-t border-b p-2">
-        <img src="/wechat.svg" class="h-4" alt=""/>
+        <img src="/wechat.svg" class="h-4" alt="wechat"/>
       </div>
       <a class="border rounded-tr-lg rounded-br-lg p-2" href={donate.paypalUrl} target="_blank">
-        <img src="/paypal.svg" class="h-4" alt=""/>
+        <img src="/paypal.svg" class="h-4" alt="paypal"/>
       </a>
     </div>
     <div class="qrshow">
-      <img src={donate.alipayQRCode} alt=""/>
+      <img src={donate.alipayQRCode} alt="alipayQRCode"/>
     </div>
     <div class="qrshow">
-      <img src={donate.wechatQRCode} alt=""/>
+      <img src={donate.wechatQRCode} alt="wechatQRCode"/>
     </div>
   </div>
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -66,7 +66,7 @@ let tagCount = getCountByTagName(blogs);
     }
   </div>
   <div id="personal-info" class="hidden break-all overflow-y-auto pb-8" style="height: calc(100vh - 64px)">
-    <img class="avatar my-4 mx-auto" src={site.avatar} alt=""/>
+    <img class="avatar my-4 mx-auto" src={site.avatar} alt="avatar"/>
     <div class="mb-2 text-center">{site.motto}</div>
     <div class="flex items-center justify-center flex-wrap">
       {

--- a/src/components/PostTitle.astro
+++ b/src/components/PostTitle.astro
@@ -9,7 +9,9 @@ const {title, date, category, tags, lastModified = '', readingTime = {}} = Astro
   <!-- title -->
   <div class="flex items-center">
     <div class="flex text-xl font-bold">
-      {title}
+      <h1>
+        {title}
+      </h1>
     </div>
   </div>
 

--- a/src/components/Profile.astro
+++ b/src/components/Profile.astro
@@ -3,7 +3,7 @@ import {site, infoLinks} from "../consts";
 ---
 
 <div class="shadow-lg rounded-lg h-64 w-auto flex flex-col items-center justify-center bg-skin-card">
-  <img class="avatar mb-4" src={site.avatar} alt=""/>
+  <img class="avatar mb-4" src={site.avatar} alt="avatar"/>
   <div class="mb-2 text-center">{site.motto}</div>
   <div class="flex items-center justify-center flex-wrap">
     {


### PR DESCRIPTION
I've enhanced the SEO performance of this template according to SEO standards.

Please note, although I've wrapped the blog title in an `<h1>` tag to meet SEO requirements, the framework will convert the first-level headings in markdown articles to `<h1>` tags. Therefore, having multiple `<h1>` tags will still not comply with SEO standards. 

You need to downgrade all first-level markdown headings in the blog by one level. 

You can achieve this using the replace feature in VS Code or by using Linux sed. 

That's all.