### PR TITLE
fix: missing default img alt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,8 @@ function customRehypeLazyLoadImage() {
       if (node.tagName === 'img') {
         node.properties['data-src'] = node.properties.src
         node.properties.src = '/spinner.gif'
+        node.properties['data-alt'] = node.properties.alt
+        node.properties.alt = 'default'
       }
     })
   }

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -59,9 +59,13 @@ const {frontmatter = {comment: false, donate: false, toc: false, mathjax: false,
         if (entry.isIntersecting) {
           const image = entry.target;
           const data_src = image.getAttribute("data-src");
+          const data_alt = image.getAttribute("data-alt");
           image.setAttribute("data-fancybox", "gallery")
           if(data_src){
             image.setAttribute("src", data_src);
+          }
+          if(data_alt){
+            image.setAttribute("alt", data_alt);
           }
           observer.unobserve(image);
         }


### PR DESCRIPTION
Using lazy-loading to enhance performance is a great job.
However, you need to be aware that this change will result in a missing alt attribute if the markdown link's alt text is missing.

I've fixed it.

You can use an SEO analyzer to verify it.

![Screenshot 2024-03-28 005045](https://github.com/cirry/astro-yi/assets/112839915/e54fa61d-7131-44bf-af1c-029169856494)
