### PR TITLE
fix: the blog drafts leaded when building

### DIFF
--- a/src/components/PostViewTitle.astro
+++ b/src/components/PostViewTitle.astro
@@ -2,7 +2,7 @@
 import {formatDate} from "../utils/formatDate";
 import {dealLabel} from "../utils/dealLabel";
 import {t} from '../i18n/utils'
-const {title, date, slug, category, tags, sticky = false} = Astro.props
+const {title, date, slug, category, tags, sticky = false, draft = false} = Astro.props
 ---
 
 <div class="text-skin-base">
@@ -22,6 +22,16 @@ const {title, date, slug, category, tags, sticky = false} = Astro.props
         <i class="ri-calendar-2-fill"/>
         <div>{formatDate(date)}</div>
       )
+    }
+
+    <!-- draft -->
+    {
+      draft && 
+        <>
+          <div class="divider-vertical" />
+          <i class="ri-git-pr-draft-line" />
+          <div>draft</div>
+        </>
     }
 
     <!-- category -->

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,7 +9,9 @@ import Donate from '../../components/Donate.astro'
 import {donate} from "../../consts";
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('blog');
+  const blogEntries = (await getCollection('blog')).filter(({data}) => {
+    return import.meta.env.PROD ? !data.draft : true
+  });
   return blogEntries.map(entry => ({
     params: {slug: entry.slug}, props: {entry,},
   }));

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,7 +3,9 @@ import {site} from "../consts";
 import {getCollection} from "astro:content";
 
 export async function GET(context) {
-  const blog = await getCollection('blog');
+  const blog = (await getCollection('blog')).filter(({data}) => {
+    return import.meta.env.PROD ? !data.draft : true
+  });
   return rss({
     title: site.title,
     description: site.description,

--- a/src/utils/getCollectionByName.ts
+++ b/src/utils/getCollectionByName.ts
@@ -1,12 +1,12 @@
 import {getCollection} from "astro:content";
 
 export const getCollectionByName = async (name: string) => {
-  let posts = await getCollection(name)
+  let posts = await getCollection(name);
   if (posts && posts.length > 0 ) {
-    return posts.filter(post => !post.data.draft).map(post => {
-      return post
-    })
-  }else {
+    return posts.filter(({data}) => {
+      return import.meta.env.PROD ? !data.draft : true
+    });
+  } else {
     return []
   }
 }

--- a/src/utils/getCountByCategory.ts
+++ b/src/utils/getCountByCategory.ts
@@ -2,12 +2,14 @@ import _ from 'lodash'
 import { dealLabel } from './dealLabel'
 
 const getCountByCategory = (posts) => {
-    let category: string[] = [];
-    const filteredPosts = posts.filter(({ data }) => !data.draft);
-    filteredPosts.forEach(post => {
-        category = _.compact([...category, ..._.flattenDeep(dealLabel(post.data.category))])
-    });
-    return _.countBy(category);
+  let category: string[] = [];
+  const filteredPosts = posts.filter(({data}) => {
+    return import.meta.env.PROD ? !data.draft : true
+  });
+  filteredPosts.forEach(post => {
+    category = _.compact([...category, ..._.flattenDeep(dealLabel(post.data.category))])
+  });
+  return _.countBy(category);
 };
 
 export default getCountByCategory;

--- a/src/utils/getCountByTagName.ts
+++ b/src/utils/getCountByTagName.ts
@@ -2,12 +2,14 @@ import _ from 'lodash'
 import { dealLabel } from './dealLabel'
 
 const getCountByTagName = (posts) => {
-    let tags: string[] = [];
-    const filteredPosts = posts.filter(({ data }) => !data.draft);
-    filteredPosts.forEach(post => {
-        tags = _.compact([...tags, ..._.flattenDeep(dealLabel(post.data.tags))])
-    });
-    return _.countBy(tags);
+  let tags: string[] = [];
+  const filteredPosts = posts.filter(({data}) => {
+    return import.meta.env.PROD ? !data.draft : true
+  });
+  filteredPosts.forEach(post => {
+    tags = _.compact([...tags, ..._.flattenDeep(dealLabel(post.data.tags))])
+  });
+  return _.countBy(tags);
 };
 
 export default getCountByTagName;

--- a/src/utils/getPostsByCategory.ts
+++ b/src/utils/getPostsByCategory.ts
@@ -2,6 +2,6 @@ import _ from 'lodash'
 import { dealLabel } from './dealLabel';
 
 const getPostsByCategory = (posts, category: string) =>
-    posts.filter(post => _.flattenDeep(dealLabel(post.data.category)).includes(category))
+  posts.filter(post => _.flattenDeep(dealLabel(post.data.category)).includes(category))
 
 export default getPostsByCategory;

--- a/src/utils/getPostsByTag.ts
+++ b/src/utils/getPostsByTag.ts
@@ -2,5 +2,5 @@ import _ from 'lodash'
 import { dealLabel } from './dealLabel';
 
 const getPostsByTag = (posts, tag: string) =>
-    posts.filter(post => _.flattenDeep(dealLabel(post.data.tags)).includes(tag))
+  posts.filter(post => _.flattenDeep(dealLabel(post.data.tags)).includes(tag))
 export default getPostsByTag;

--- a/src/utils/getUniqeCategory.ts
+++ b/src/utils/getUniqeCategory.ts
@@ -3,7 +3,9 @@ import { dealLabel } from './dealLabel';
 
 const getUniqueCategory = (posts) => {
     let category: string[] = [];
-    const filteredPosts = posts.filter(({ data }) => !data.draft);
+    const filteredPosts = posts.filter(({data}) => {
+        return import.meta.env.PROD ? !data.draft : true
+    });
     filteredPosts.forEach(post => {
         category = [...category, ..._.flattenDeep(dealLabel(post.data.category))]
             .filter(

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -3,7 +3,9 @@ import { dealLabel } from './dealLabel';
 
 const getUniqueTags = (posts) => {
     let tags: string[] = [];
-    const filteredPosts = posts.filter(({ data }) => !data.draft);
+    const filteredPosts = posts.filter(({data}) => {
+        return import.meta.env.PROD ? !data.draft : true
+    });
     filteredPosts.forEach(post => {
         tags = [...tags, ...dealLabel(post.data.tags)]
             .filter(

--- a/src/utils/sortPostsByDate.ts
+++ b/src/utils/sortPostsByDate.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs'
 export const sortPostsByDate = (posts) =>
     posts
-        .filter(({ data }) => !data.draft)
+        .filter(({data}) => {
+            return import.meta.env.PROD ? !data.draft : true
+        })
         .sort((a, b) => dayjs(b.data.date).unix() - dayjs(a.data.date).unix());


### PR DESCRIPTION
Based on your current design, articles tagged with draft will still be generated in all environments and can be accessed. 
They might even appear in the `sitemap` and `rss.xml`. 

I've fixed this issue :)