### PR TITLE
style: enhance feed preview

### DIFF
--- a/src/components/FeedPreview.astro
+++ b/src/components/FeedPreview.astro
@@ -11,8 +11,11 @@ import {t} from '../i18n/utils'
   >
     {
       body.length > 140
-        ? body.substring(0, 140).replace(/#/gi, "") + "..."
-        : body
+        ? body.replace(/^#+/gm, "")
+              .replace(/!?\[.*?\]\(.*?\)/g, "")
+              .substring(0, 140) + "..."
+        : body.replace(/^#+/gm, "")
+              .replace(/!?\[.*?\]\(.*?\)/g, "")
     }
   </p>
   <div class="flex items-center justify-between mt-2 text-sm">


### PR DESCRIPTION
The preview of the feed list displays links in markdown format or image links, which is a bit odd.

I've fixed it.