### PR TITLE
fix: incorrect og in blog pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# patches
+patches/

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,7 +3,12 @@ import '../styles/index.css'
 import {site, config} from "../consts";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const {mathjax = false, mermaid = false} = Astro.props
+const {title = site.title, description = site.description, mathjax = false, mermaid = false} = Astro.props
+let ogImage = '';
+if (title === site.title) {
+  ogImage = new URL(site.avatar, Astro.site?.href).href;
+}
+// console.log(Astro.props.title)
 ---
 <head>
   <!-- Global Metadata -->
@@ -15,23 +20,23 @@ const {mathjax = false, mermaid = false} = Astro.props
   <link rel="canonical" href={canonicalURL}/>
 
   <!-- Primary Meta Tags -->
-  <meta name="title" content={site.title}/>
-  <meta name="description" content={site.description}/>
+  <meta name="title" content={title}/>
+  <meta name="description" content={description}/>
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website"/>
   <meta property="og:url" content={Astro.url}/>
-  <meta property="og:title" content={site.title}/>
-  <meta property="og:description" content={site.description}/>
-  <meta property="og:image" content={new URL(site.avatar, Astro.site?.href).href}/>
-  <meta property="og:image:alt" content={site.description}/>
+  <meta property="og:title" content={title}/>
+  <meta property="og:description" content={description}/>
+  <meta property="og:image" content={ogImage}/>
+  <!-- <meta property="og:image:alt" content={site.description}/> -->
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image"/>
   <meta property="twitter:url" content={Astro.url}/>
-  <meta property="twitter:title" content={site.title}/>
-  <meta property="twitter:description" content={site.description}/>
-  <meta property="twitter:image" content={new URL(site.avatar, Astro.site?.href).href}/>
+  <meta property="twitter:title" content={title}/>
+  <meta property="twitter:description" content={description}/>
+  <meta property="twitter:image" content={ogImage}/>
 
   <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="msapplication-TileColor" content="#da532c"/>
@@ -39,7 +44,7 @@ const {mathjax = false, mermaid = false} = Astro.props
   <meta name="theme-color" content="#ffffff"/>
 
   <link rel="sitemap" href="/sitemap-0.xml"/>
-  <title>{site.title}</title>
+  <title>{title}</title>
   <script is:inline src="/toggle-theme.js"></script>
   {
     mathjax && <script async type="text/javascript" src="/load-mathjax.js"></script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,39 +9,52 @@ import {comment, config} from "../consts";
 import ScrollToTop from '../components/ScrollToTop.astro'
 import {t}from '../i18n/utils'
 
-const {frontmatter = {comment: false, donate: false, toc: false, mathjax: false, mermaid: false}} = Astro.props
+const {
+  frontmatter = {
+    comment: false,
+    donate: false,
+    toc: false,
+    mathjax: false,
+    mermaid: false,
+  },
+} = Astro.props;
 ---
 
 <html lang={config.lang}>
-<BaseHead mathjax={frontmatter.mathjax} mermaid={frontmatter.mermaid} />
+<BaseHead
+  title={frontmatter.title}
+  description={frontmatter.description}
+  mathjax={frontmatter.mathjax}
+  mermaid={frontmatter.mermaid}
+/>
 
 <body class="bg-skin-secondary">
 <Header/>
 <main class="container p-4  pt-20 text-skin-base min-h-full pb-32 relative" id="app">
-  <div class="grid grid-cols-4 gap-8">
-    <div class="col-span-4 xl:col-span-3 space-y-4">
+      <div class="grid grid-cols-4 gap-8">
+        <div class="col-span-4 xl:col-span-3 space-y-4">
       <button class="flex items-center text-md cursor-pointer hover:text-skin-active outline-none" style="background-color: inherit;" onclick="history.back()">
         <i class="ri-arrow-left-line mr-2"/>
         <span>{t('home.goBack')}</span>
-      </button>
+          </button>
       <slot/>
       {
         frontmatter.comment && comment.enable &&
         <Comment></Comment>
       }
-    </div>
-    <div class="hidden xl:block col-span-1 relative">
+        </div>
+        <div class="hidden xl:block col-span-1 relative">
       <Profile></Profile>
       {
         frontmatter.toc &&
         <Toc></Toc>
       }
-    </div>
+        </div>
     <ScrollToTop></ScrollToTop>
-  </div>
+      </div>
   <Footer/>
-</main>
-</body>
+    </main>
+  </body>
 </html>
 
 


### PR DESCRIPTION
In the current version, the Open Graph does not display the correct title and description on the blog page. For example, with my latest blog [post](https://www.vinny987.xyz/blog/2024/secure-local-server-exposure-with-cloudflare-tunnel-a-complete-setup-guide-from-scratch), it looks like this:

![image](https://github.com/user-attachments/assets/9d1b04d2-709a-4a57-be7e-97569e25d3ac)

![image](https://github.com/user-attachments/assets/4aacb39d-62f5-4ef7-9acd-e37d9f1abbb9)

I've fixed it 🙂