### PR TITLE
chore: Integrate all analytics features into one

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,8 @@
 ---
 import '../styles/index.css'
 import {site, config} from "../consts";
+import UmamiAnalytics from '../components/UmamiAnalytics.astro';
+import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const {title = site.title, description = site.description, mathjax = false, mermaid = false} = Astro.props
@@ -58,22 +60,7 @@ if (title === site.title) {
   {
     config.busuanzi && <script async src="https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
   }
-  <!-- Google tag (gtag.js) -->
-  {
-    config.ga &&
-    <>
-      <script src={"https://www.googletagmanager.com/gtag/js?id=" +　config.ga}></script>
-      <script define:vars={{ga: config.ga}}>
-        window.dataLayer = window.dataLayer || [];
+  <GoogleAnalytics />
+  <UmamiAnalytics />
 
-        function gtag() {
-          dataLayer.push(arguments);
-        }
-
-        gtag('js', new Date());
-
-        gtag('config', ga);
-      </script>
-    </>
-  }
 </head>

--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -1,0 +1,22 @@
+---
+import { analytics } from "../consts";
+const { enable: allEnable, gaConfig } = analytics;
+const { enable: gaEnable, id } = gaConfig ?? {};
+const shouldLoadGA = allEnable && gaEnable && id;
+---
+
+{shouldLoadGA && (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${id}`}></script>
+    <script define:vars={{ ga: id }}>
+      window.dataLayer = window.dataLayer || [];
+
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+
+      gtag('js', new Date());
+      gtag('config', id);
+    </script>
+  </>
+)}

--- a/src/components/UmamiAnalytics.astro
+++ b/src/components/UmamiAnalytics.astro
@@ -1,0 +1,10 @@
+---
+import { analytics } from "../consts";
+const { enable: allEnable, umamiConfig } = analytics;
+const { enable: umamiEnable, id, url } = umamiConfig ?? {};
+const shouldLoadUmami = allEnable && umamiEnable && id && url;
+---
+
+{shouldLoadUmami && (
+  <script defer src={url} data-website-id={id}></script>
+)}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,8 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
+import { AnalyticsConfig } from "./types/analyticsTypes"
+
 /**
  * title {string} website title
  * favicon {string} website favicon url
@@ -48,7 +50,6 @@ export const config = {
   busuanzi: false,
   lang: 'en', // en | zh-cn | zh-Hant | cs
   codeFoldingStartLines: 16, // Need to re-run the project to take effect
-  ga: false, // If you want to integrate with Google Analytics, just enter your GA-ID here.
 
   // memos config
   memosUrl: '', // https://xxxx.xxx.xx
@@ -222,4 +223,25 @@ export const comment = {
     'data-lang': "",
     'crossorigin': "",
   }
+
+  // 
 }
+
+/**
+ * Analytics Feature Configuration
+ * 
+ * This file centralizes the analytics configuration for the application.
+ * It defines and exports the default settings for Umami and Google Analytics.
+ */
+export const analytics: AnalyticsConfig = {
+  enable: false,
+  umamiConfig: {
+    enable: false,
+    id: "",
+    url: ""
+  },
+  gaConfig: {
+    enable: false,
+    id: ""
+  }
+};

--- a/src/types/analyticsTypes.ts
+++ b/src/types/analyticsTypes.ts
@@ -1,0 +1,31 @@
+/*
+  This module defines the interfaces for website analytics configurations,
+  including settings for Umami and Google Analytics, as well as overall configuration.
+  Depending on your project requirements, you may selectively enable one or more analytics tools.
+*/
+
+export interface UmamiConfig {
+  // Flag indicating whether Umami analytics is enabled
+  enable: boolean;
+  // Unique identifier for Umami analytics
+  id: string;
+  // The base URL for the Umami service (e.g., the deployment URL of the Umami instance)
+  url: string;
+}
+
+export interface GAConfig {
+  // Flag indicating whether Google Analytics tracking is enabled
+  enable: boolean;
+  // Tracking ID for Google Analytics (e.g., "UA-XXXXXX-X" or "G-XXXXXXXXXX")
+  id: string;
+}
+
+export interface AnalyticsConfig {
+  // Global flag to enable or disable overall analytics functionality
+  enable: boolean;
+  // Optional configuration for Umami analytics; if not provided, Umami will not be active
+  umamiConfig?: UmamiConfig;
+  // Optional configuration for Google Analytics; if not provided, Google Analytics will not be active
+  gaConfig?: GAConfig;
+}
+  


### PR DESCRIPTION
In this PR, I do two things:

1. Add a new analytics tool called [umami](https://github.com/umami-software/umami).
2. Integrate all analytics to specific parameters `config.analytics`. I also write a type file `analytics.ts` for strict and explain it.
	
> Note: I moved the Google Analytics stuff to new parameters. This new feature is not downward compatible.