### PR TITLE
fix: post last updated warning

### DIFF
--- a/src/components/PostTitle.astro
+++ b/src/components/PostTitle.astro
@@ -4,8 +4,11 @@ import {dealLabel} from "../utils/dealLabel";
 import {t} from '../i18n/utils'
 import dayjs from "dayjs";
 const {title, date, category, tags, lastModified = '', draft = false, readingTime = {}} = Astro.props
-let lastModifiedFormat = dayjs(lastModified).format('YYYY-MM-DD');
-let dateFormat = dayjs(date).format('YYYY-MM-DD');
+const lastModifiedDate = dayjs(lastModified === '' ? date : lastModified);
+const publishDate = dayjs(date);
+const mostRecentDate = lastModifiedDate.isAfter(publishDate) ? lastModifiedDate : publishDate;
+const mostRecent = mostRecentDate.format('YYYY-MM-DD');
+const currentDate = dayjs();
 ---
 
 <div>
@@ -55,7 +58,7 @@ let dateFormat = dayjs(date).format('YYYY-MM-DD');
     }
   </div>
   {
-    lastModified && lastModifiedFormat !== dateFormat &&
-    <div class="shadow w-auto flex bg-skin-card p-2 rounded text-sm"><i class="ri-error-warning-line mr-1"/>{t('post.lastUpdatedTip1')} {formatDate(lastModified)} {t('post.lastUpdatedTip2')} </div>
+    currentDate.isAfter(mostRecentDate.add(6, 'month')) &&
+    <div class="shadow w-auto flex bg-skin-card p-2 rounded text-sm"><i class="ri-error-warning-line mr-1"/>{t('post.lastUpdatedTip1')} {formatDate(mostRecent)} {t('post.lastUpdatedTip2')} </div>
   }
 </div>


### PR DESCRIPTION
Currently there is a bug where a warning is shown on a post if it contains a last modified date regardless of how recent that date was.

Example:
![image](https://github.com/user-attachments/assets/c070374c-6eb0-40be-a73e-e174033afadc)

In the above example, the last modified date was just a day ago (today being 23-Feb-2025), which I don't think requires a warning.

This PR fixes this, and the warning is shown only if the last modified (or created) was 6 months ago.