### PR TITLE
fix 分类与标签页没有显示对应title的问题; basehead 全站title的格式修改为 首页仅显示站名, 子页显示 `title…

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,8 +6,9 @@ import GoogleAnalytics from '@/components/GoogleAnalytics.astro';
 import BusuanziAnalytics from '@/components/BusuanziAnalytics.astro';
 import getUrl from "@/utils/getUrl";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const {title = site.title, description = site.description, mathjax = false, mermaid = false, ogImage:ogimage = ''} = Astro.props
+const {description = site.description, mathjax = false, mermaid = false, ogImage:ogimage = ''} = Astro.props
 let ogImage =  ogimage || new URL(Astro.url.pathname, Astro.site?.href).href;
+let title = Astro.props.title ? `${Astro.props.title} - ${site.title}` : site.title;
 ---
 <head>
   <!-- Global Metadata -->

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -12,7 +12,7 @@ const {frontmatter = {comment: false, donate: false}} = Astro.props
 ---
 
 <html lang={config.lang}>
-<BaseHead/>
+<BaseHead title={Astro.props.title} />
 
 <body class="bg-skin-secondary relative">
 <Header/>

--- a/src/pages/category/[category].astro
+++ b/src/pages/category/[category].astro
@@ -27,7 +27,7 @@ const categoryPosts = getPostsByCategory(posts, category);
 const resultPosts = sortPostsByDate(categoryPosts);
 ---
 
-<IndexPage>
+<IndexPage title={category}>
   <SearchTitle label={category}/>
   <ul class="text-skin-base">
     {

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -21,7 +21,7 @@ const tagPosts = getPostsByTag(posts, tag);
 const resultPosts = sortPostsByDate(tagPosts);
 ---
 
-<IndexPage>
+<IndexPage title={tag}>
   <SearchTitle label={tag}/>
   <ul class="text-skin-base">
     {

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,12 +3,13 @@ import IndexPage from "@/layouts/IndexPage.astro";
 import {getCollectionByName} from "@/utils/getCollectionByName";
 import getUniqueTags from "@/utils/getUniqueTags";
 import getUrl from "@/utils/getUrl";
+import {t} from '../../i18n/utils'
 
 const blogs = await getCollectionByName('blog')
 let tagArr = getUniqueTags(blogs);
 ---
 
-<IndexPage>
+<IndexPage title={t('sidebar.tags')}>
   <div class="flex flex-wrap">
     {
       (


### PR DESCRIPTION
… - 站名` 的形式

子页title示例:New features - Astro Theme Yi